### PR TITLE
example: Add detect script

### DIFF
--- a/example/detect.py
+++ b/example/detect.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- mode: python; python-indent-offset: 4; indent-tabs-mode: nil -*-
+# SPDX-License-Indentifier: MIT
+
+''' Example '''
+
+import os
+import sys
+
+PARENT_PATH = os.path.join(__file__, '..', '..', 'awoxmeshlight', '..')
+LIB_PATH = os.path.abspath(PARENT_PATH)
+sys.path.append(LIB_PATH)
+
+from awoxmeshlight import AwoxMeshLight
+
+MAC = os.getenv('MAC') or "A4:C1:38:FF:FF:FF"
+print("info: Looking up mac=%s" % MAC)
+LIGHT = AwoxMeshLight(MAC)
+LIGHT.connect()
+print("info: model=%s" % LIGHT.getModelNumber())
+print("info: hardware=%s" % LIGHT.getHardwareRevision())
+print("info: firmware=%s" % LIGHT.getFirmwareRevision())
+LIGHT.disconnect()


### PR DESCRIPTION
It was used using this way:

    MAC=a4:c1:38:FF:FF:FF ./example/detect.py
    #| info: Looking up mac=a4:c1:38:FF:FF:FF
    #| info: model=b'SMLm_C9\x00'

Change-Id: I16faa12cffcff8bdb86715e0dfcc281cdae97245
Origin: https://github.com/CrossStream/python-awox-mesh-light/tree/sandbox/rzr/review/master
Signed-off-by: Philippe Coval <rzr@users.sf.net>