### PR TITLE
Adds in a retry for connect method

### DIFF
--- a/awoxmeshlight/__init__.py
+++ b/awoxmeshlight/__init__.py
@@ -136,6 +136,25 @@ class AwoxMeshLight:
                 logger.info ("Unexpected pair value : %s", repr (reply))
             self.disconnect ()
             return False
+        
+    def connectWithRetry(self, num_tries = 1, mesh_name = None, mesh_password = None):
+        """
+        Args:
+           num_tries: The number of attempts to connect.
+           mesh_name: The mesh name as a string.
+           mesh_password: The mesh password as a string.
+        """
+        connected = False
+        attempts = 0
+        while (not connected and attempts < num_tries ):
+            try:
+                connected = self.connect(mesh_name, mesh_password)
+            except btle.BTLEDisconnectError:
+                logger.info("connection_error: retrying for %s time", attempts)
+            finally:
+                attempts += 1
+
+        return connected
 
     def setMesh (self, new_mesh_name, new_mesh_password, new_mesh_long_term_key):
         """


### PR DESCRIPTION
I found that with my pi, it threw an exception sometimes on connect, but the next connection would work. This PR is to just loop if bluetooth raises an error fo a configurable number of times.

```
LIGHT.connectWithRetry(3)
```

loops 3 times around the connect